### PR TITLE
MultiLanguage support, capture fixes

### DIFF
--- a/Text-Grab/MainWindow.xaml.cs
+++ b/Text-Grab/MainWindow.xaml.cs
@@ -11,6 +11,7 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
+using System.Windows.Threading;
 using Windows.Globalization;
 using Windows.Media.Ocr;
 using Windows.System.UserProfile;
@@ -32,6 +33,25 @@ namespace Text_Grab
 
         public List<string> InstalledLanguages => GlobalizationPreferences.Languages.ToList();
 
+        // add padding to image to reach a minimum size
+        private Bitmap PadImage(Bitmap image, int minW = 64, int minH = 64)
+        {
+            if (image.Height >= minH && image.Width >= minW)
+                return image;
+
+            int width = Math.Max(image.Width + 16, minW + 16);
+            int height = Math.Max(image.Height + 16, minH + 16);
+
+            // Create a compatible bitmap
+            Bitmap dest = new Bitmap(width, height, image.PixelFormat);
+            using (Graphics gd = Graphics.FromImage(dest))
+            {
+                gd.Clear(image.GetPixel(0, 0));
+                gd.DrawImageUnscaled(image, 8, 8);
+            }
+            return dest;
+        }
+
         private async Task<string> GetRegionsText(Rectangle selectedRegion)
         {
             Bitmap bmp = new Bitmap(selectedRegion.Width, selectedRegion.Height, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
@@ -42,11 +62,15 @@ namespace Text_Grab
             int thisCorrectedTop = (int)(absPosPoint.Y) + selectedRegion.Top;
 
             g.CopyFromScreen(thisCorrectedLeft, thisCorrectedTop, 0, 0, bmp.Size, CopyPixelOperation.SourceCopy);
+            bmp = PadImage(bmp);
 
-            string ocrText = await ExtractText(bmp, InstalledLanguages.FirstOrDefault());
-            ocrText.Trim();
+            // use currently selected Language
+            string inputLang = InputLanguageManager.Current.CurrentInputLanguage.Name;
+            if (!InstalledLanguages.Contains(inputLang)) 
+                inputLang = InstalledLanguages.FirstOrDefault();
 
-            return ocrText;
+            string ocrText = await ExtractText(bmp, inputLang);
+            return ocrText.Trim();
         }
 
         private async Task<string> GetClickedWord(System.Windows.Point clickedPoint)
@@ -66,10 +90,13 @@ namespace Text_Grab
 
             System.Windows.Point adjustedPoint = new System.Windows.Point(clickedPoint.X, clickedPoint.Y);
 
-            string ocrText = await ExtractText(bmp, InstalledLanguages.FirstOrDefault(), adjustedPoint);
-            ocrText.Trim();
+            // use currently selected Language
+            string inputLang = InputLanguageManager.Current.CurrentInputLanguage.Name;
+            if (!InstalledLanguages.Contains(inputLang))
+                inputLang = InstalledLanguages.FirstOrDefault();
 
-            return ocrText;
+            string ocrText = await ExtractText(bmp, inputLang, adjustedPoint);
+            return ocrText.Trim();
         }
 
         BitmapImage BitmapToImageSource(Bitmap bitmap)
@@ -250,14 +277,17 @@ namespace Text_Grab
 
             string grabbedText = "";
 
+            // remove selectBorder before capture - force screen Re-render to actually remove it
+            try { RegionClickCanvas.Children.Remove(selectBorder); } catch { }
             RegionClickCanvas.Background.Opacity = 0;
+            RegionClickCanvas.UpdateLayout();
+            RegionClickCanvas.Dispatcher.Invoke(() => { }, DispatcherPriority.Render);
 
             if (regionScaled.Width < 3 || regionScaled.Height < 3)
                 grabbedText = await GetClickedWord(new System.Windows.Point(xDimScaled, yDimScaled));
             else
                 grabbedText = await GetRegionsText(regionScaled);
 
-            RegionClickCanvas.Children.Remove(selectBorder);
             if (string.IsNullOrWhiteSpace(grabbedText) == false)
             {
                 Clipboard.SetText(grabbedText);

--- a/Text-Grab/OSInterop.cs
+++ b/Text-Grab/OSInterop.cs
@@ -61,7 +61,7 @@ static class WPFExtensionMethods
             IntPtr hmonitor = OSInterop.MonitorFromWindow(new HandleRef((object)null, helper.EnsureHandle()), 2);
             OSInterop.MONITORINFOEX info = new OSInterop.MONITORINFOEX();
             OSInterop.GetMonitorInfo(new HandleRef((object)null, hmonitor), info);
-            r = new Int32Rect(info.rcWork.left, info.rcWork.top, info.rcWork.width, info.rcWork.height);
+            r = new Int32Rect(info.rcMonitor.left, info.rcMonitor.top, info.rcMonitor.width, info.rcMonitor.height);
         }
         return new Point(r.X, r.Y);
     }

--- a/Text-Grab/Text-Grab.csproj
+++ b/Text-Grab/Text-Grab.csproj
@@ -15,21 +15,12 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <PlatformTarget>x86</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <PlatformTarget>x86</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
-
-  <ItemGroup>
-    <COMReference Include="{215d64d2-031c-33c7-96e3-61794cd1ee61}">
-      <WrapperTool>tlbimp</WrapperTool>
-      <VersionMinor>4</VersionMinor>
-      <VersionMajor>2</VersionMajor>
-      <Guid>215d64d2-031c-33c7-96e3-61794cd1ee61</Guid>
-    </COMReference>
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.SDK.Contracts" Version="10.0.19041.1" />


### PR DESCRIPTION
- Use current selected language for OCR
- Fix capture offset when the System Tray is at the top of the screen
- Hide selection border before capturing
- Add padding to captured image to allow capturing small areas