### PR TITLE
Provide culture-sensitive string comparison

### DIFF
--- a/Text-Grab/Views/GrabFrame.xaml.cs
+++ b/Text-Grab/Views/GrabFrame.xaml.cs
@@ -212,7 +212,7 @@ namespace Text_Grab.Views
 
                     if ((bool)ExactMatchChkBx.IsChecked)
                     {
-                        if (wordString == searchWord)
+                        if (wordString.Equals(searchWord, StringComparison.CurrentCulture))
                         {
                             wordBorderBox.Select();
                             numberOfMatches++;
@@ -221,7 +221,7 @@ namespace Text_Grab.Views
                     else
                     {
                         if (!string.IsNullOrWhiteSpace(searchWord)
-                            && wordString.ToLower().Contains(searchWord.ToLower()))
+                            && wordString.Contains(searchWord, StringComparison.CurrentCultureIgnoreCase))
                         {
                             wordBorderBox.Select();
                             numberOfMatches++;


### PR DESCRIPTION
`string.Contains ` uses ordinal comparison, which is too restrictive in some language/culture settings.