### PR TITLE
Allow checkbox caption to wrap

### DIFF
--- a/Text-Grab/Views/SettingsWindow.xaml
+++ b/Text-Grab/Views/SettingsWindow.xaml
@@ -51,16 +51,14 @@
                 </Grid>
 
                 <!--  Show Toast on success  -->
-                <StackPanel Margin="0,12,0,0" Orientation="Horizontal">
-                    <CheckBox
-                        Name="ShowToastCheckBox"
-                        VerticalContentAlignment="Center"
-                        Style="{StaticResource labelText}">
-                        <TextBlock Style="{StaticResource TextBodyNormal}">
-                            Show Toast when text is copied. Opens window to display and edit text.
-                        </TextBlock>
-                    </CheckBox>
-                </StackPanel>
+                <CheckBox Margin="0,12,0,0"
+                    Name="ShowToastCheckBox"
+                    VerticalContentAlignment="Center"
+                    Style="{StaticResource labelText}">
+                    <TextBlock Style="{StaticResource TextBodyNormal}">
+                        Show Toast when text is copied. Opens window to display and edit text.
+                    </TextBlock>
+                </CheckBox>
 
                 <!--  default launch  -->
                 <TextBlock


### PR DESCRIPTION
The first checkbox in the Settings window is in a StackPanel which prevents the caption text from wrapping. Fixed by removing the StackPanel