### PR TITLE
Fix mousewheel scroll handler in EditTextWindow

### DIFF
--- a/Text-Grab/Views/EditTextWindow.xaml
+++ b/Text-Grab/Views/EditTextWindow.xaml
@@ -218,7 +218,6 @@
             Foreground="White"
             HorizontalScrollBarVisibility="Auto"
             IsInactiveSelectionHighlightEnabled="True"
-            Mouse.MouseWheel="PassedTextControl_MouseWheel"
             SpellCheck.IsEnabled="True"
             Style="{DynamicResource TextBoxStyle1}"
             Text="{Binding CopiedText, Mode=OneWay}"

--- a/Text-Grab/Views/EditTextWindow.xaml.cs
+++ b/Text-Grab/Views/EditTextWindow.xaml.cs
@@ -57,7 +57,7 @@ namespace Text_Grab
                 PassedTextControl.TextAlignment = TextAlignment.Right;
             }
 
-            PassedTextControl.PreviewMouseWheel += PassedTextControl_PreviewMouseWheel;
+            PassedTextControl.PreviewMouseWheel += HandlePreviewMouseWheel;
         }
 
         public EditTextWindow(string rawPassedString)
@@ -754,7 +754,7 @@ namespace Text_Grab
                 e.CanExecute = false;
         }
 
-        private void PassedTextControl_PreviewMouseWheel(object sender, MouseWheelEventArgs e)
+        private void HandlePreviewMouseWheel(object sender, MouseWheelEventArgs e)
         {
             // Source: StackOverflow, read on Sep. 10, 2021
             // https://stackoverflow.com/a/53698638/7438031

--- a/Text-Grab/Views/EditTextWindow.xaml.cs
+++ b/Text-Grab/Views/EditTextWindow.xaml.cs
@@ -56,6 +56,8 @@ namespace Text_Grab
             {
                 PassedTextControl.TextAlignment = TextAlignment.Right;
             }
+
+            PassedTextControl.PreviewMouseWheel += PassedTextControl_PreviewMouseWheel;
         }
 
         public EditTextWindow(string rawPassedString)
@@ -752,7 +754,7 @@ namespace Text_Grab
                 e.CanExecute = false;
         }
 
-        private void PassedTextControl_MouseWheel(object sender, MouseWheelEventArgs e)
+        private void PassedTextControl_PreviewMouseWheel(object sender, MouseWheelEventArgs e)
         {
             // Source: StackOverflow, read on Sep. 10, 2021
             // https://stackoverflow.com/a/53698638/7438031
@@ -770,6 +772,25 @@ namespace Text_Grab
                     PassedTextControl.FontSize -= 4;
             }
         }
+
+        //private void PassedTextControl_MouseWheel(object sender, MouseWheelEventArgs e)
+        //{
+        //    // Source: StackOverflow, read on Sep. 10, 2021
+        //    // https://stackoverflow.com/a/53698638/7438031
+
+        //    if (Keyboard.Modifiers != ModifierKeys.Control)
+        //        return;
+
+        //    e.Handled = true;
+
+        //    if (e.Delta > 0)
+        //        PassedTextControl.FontSize += 4;
+        //    else if (e.Delta < 0)
+        //    {
+        //        if (PassedTextControl.FontSize > 4)
+        //            PassedTextControl.FontSize -= 4;
+        //    }
+        //}
 
         private void SelectLineMenuItem_Click(object sender, RoutedEventArgs e)
         {

--- a/Text-Grab/Views/EditTextWindow.xaml.cs
+++ b/Text-Grab/Views/EditTextWindow.xaml.cs
@@ -773,25 +773,6 @@ namespace Text_Grab
             }
         }
 
-        //private void PassedTextControl_MouseWheel(object sender, MouseWheelEventArgs e)
-        //{
-        //    // Source: StackOverflow, read on Sep. 10, 2021
-        //    // https://stackoverflow.com/a/53698638/7438031
-
-        //    if (Keyboard.Modifiers != ModifierKeys.Control)
-        //        return;
-
-        //    e.Handled = true;
-
-        //    if (e.Delta > 0)
-        //        PassedTextControl.FontSize += 4;
-        //    else if (e.Delta < 0)
-        //    {
-        //        if (PassedTextControl.FontSize > 4)
-        //            PassedTextControl.FontSize -= 4;
-        //    }
-        //}
-
         private void SelectLineMenuItem_Click(object sender, RoutedEventArgs e)
         {
             SelectLine();


### PR DESCRIPTION
In EditTextWindow, the mouse wheel with CTRL depressed enlarges or reduces the size of the font. However, when there is sufficient text to invoke the vertical scrollbar, the mousewheel event (even with CTRL depressed) is handled by the scroller first (this is caused by the way WPF messages bubble up). The fix is to handle the mousewheel Preview event.