### PR TITLE
Prevent CA1416 validate platform compatibility analyzer warnings

### DIFF
--- a/Text-Grab/AssemblyInfo.cs
+++ b/Text-Grab/AssemblyInfo.cs
@@ -1,6 +1,8 @@
+using System.Runtime.Versioning;
 using System.Windows;
 using System.Windows.Media;
 
+[assembly: SupportedOSPlatform("windows10.0.19041.0")]
 [assembly: DisableDpiAwareness]
 [assembly: ThemeInfo(
     ResourceDictionaryLocation.None, //where theme specific resource dictionaries are located


### PR DESCRIPTION
The port to .NET 5, placed the "windows10.0.19041.0"  TFM in the project file. Since we create our own AssemblyInfo (GenerateAssemblyInfo is false), MSBuild can't inject the SupportedOSPlatform attribute. This leads to platform checking and many gratuitous analyzer warnings of type CA1416.  Fix is to insert the attribute into AssemblyInfo.