### PR TITLE
Update non-space joining language detection logic

### DIFF
--- a/Text-Grab/Utilities/StringMethods.cs
+++ b/Text-Grab/Utilities/StringMethods.cs
@@ -339,14 +339,4 @@ public static class StringMethods
         Regex regex = new(stringToRemove);
         return regex.Replace(stringToBeEdited, "");
     }
-
-    public static bool IsSpaceJoiningLanguage(this string wordToBeChecked)
-    {
-        Regex broadCJP = new(@"\p{IsCJKUnifiedIdeographs}|{IsCJKSymbolsandPunctuation}|{IsHiragana}|{IsKatakana}|{IsHalfwidthandFullwidthForms}");
-
-        if (broadCJP.IsMatch(wordToBeChecked))
-            return false;
-
-        return true;
-    }
 }


### PR DESCRIPTION
My attempt to fix #191.

Changes:

- Check if the user specified OCR language is Chinese or Japanese before joining the words.
- Change the regex from matching non-space joining languages (CJK) to matching space joining languages (e. g. English).
  - All words longer than one character are seen as a word in a space joining language.
    Because Chinese and Japanese characters/punctuations are single-character words.
  - As for single-character words, these characters are seen as a word in a space joining language:
    - All letters, except "other letters".
      CJK characters are "other letters", while Latin letters, Greek letters, Cyrillic letters, etc. are either "uppercase letters" or "lowercase letters".
    - Number digits, or 0-9.
- Fix the word joining logic so that there's always a space between a word in a space joining language and a word in a non-space joining language.