### PR TITLE
Check for isSpaceJoiningOCRLang when using right-to-left languages

### DIFF
--- a/Text-Grab/Utilities/ImageMethods.cs
+++ b/Text-Grab/Utilities/ImageMethods.cs
@@ -254,17 +254,22 @@ public static class ImageMethods
                 List<string> wordArray = textLine.Split().ToList();
                 wordArray.Reverse();
 
-                foreach (string wordText in wordArray)
+                if (isSpaceJoiningOCRLang)
+                    text.Append(string.Join(' ', wordArray));
+                else
                 {
-                    bool isThisWordSpaceJoining = regexSpaceJoiningWord.IsMatch(wordText);
+                    foreach (string wordText in wordArray)
+                    {
+                        bool isThisWordSpaceJoining = regexSpaceJoiningWord.IsMatch(wordText);
 
-                    if (firstWord || (!isThisWordSpaceJoining && !isPrevWordSpaceJoining))
-                        _ = text.Append(wordText);
-                    else
-                        _ = text.Append(' ').Append(wordText);
+                        if (firstWord || (!isThisWordSpaceJoining && !isPrevWordSpaceJoining))
+                            _ = text.Append(wordText);
+                        else
+                            _ = text.Append(' ').Append(wordText);
 
-                    firstWord = false;
-                    isPrevWordSpaceJoining = isThisWordSpaceJoining;
+                        firstWord = false;
+                        isPrevWordSpaceJoining = isThisWordSpaceJoining;
+                    }
                 }
 
                 if (textLine.Length > 0)


### PR DESCRIPTION
Added the logic to check for isSpaceJoiningOCRLang as mentioned here:

https://github.com/TheJoeFin/Text-Grab/pull/197#issuecomment-1280170595