### PR TITLE
Trim toast content when necessary; use base64 for toast args

### DIFF
--- a/Text-Grab/Utilities/NotificationUtilities.cs
+++ b/Text-Grab/Utilities/NotificationUtilities.cs
@@ -8,24 +8,57 @@ internal static class NotificationUtilities
 {
     internal static void ShowToast(string copiedText)
     {
-        int byteSizeCopiedText = System.Text.Encoding.Unicode.GetByteCount(copiedText);
-        // Max payload size is 5000, so I will go under that by a little bit
-        int maxArgumentSize = 4900;
-        if (byteSizeCopiedText > maxArgumentSize)
-        {
-            double lengthOfCopiedText = copiedText.Length;
-            double reductionRatio = maxArgumentSize / lengthOfCopiedText;
-            int newTrimmedLenth = (int)(lengthOfCopiedText * reductionRatio);
-            copiedText = copiedText.Substring(0, newTrimmedLenth);
-        }
-
         byte[] plainTextBytes = Encoding.UTF8.GetBytes(copiedText);
-        string encodedString = Convert.ToHexString(plainTextBytes);
 
-        new ToastContentBuilder()
+        // changed to using base64
+        // the padding '=' will be encoded as '%3D' in the toast XML, so remove them
+        string encodedString = Convert.ToBase64String(plainTextBytes).TrimEnd('='); 
+
+        // truncate toast body text first, if it is too long
+        string toastBody;
+        if (copiedText.Length > 150)
+            toastBody = copiedText.Substring(0, 150) + "...";
+        else
+            toastBody = copiedText;
+
+        // build the toast XML
+        var toast = new ToastContentBuilder()
             .AddArgument("text", encodedString)
             .AddText("Text Grab")
-            .AddText(copiedText)
-            .Show();
+            .AddText(toastBody);
+
+        int toastSizeInBytes = Encoding.UTF8.GetByteCount(toast.Content.GetContent());
+        if (toastSizeInBytes > 5000) // maximum size 5000 bytes
+        {
+            // the XML is still too large, the copied text itself will have to be truncated and some data will be lost
+
+            int bytesFree = 5000 - (toastSizeInBytes - encodedString.Length); // max length for encodedString
+
+            // 4 chars in a base64 string = 3 bytes, so convert it to max length for plainTextBytes
+            int maxTextBytes = bytesFree / 4 * 3; // max length for plainTextBytes
+
+            // as we removed the padding '='s, maybe we can fit in 2 or 3 more base64 chars, which is 1 or 2 text bytes
+            if (bytesFree % 4 >= 2)
+                maxTextBytes += bytesFree % 4 - 1;
+
+            // convert only as much as bytesFree bytes
+
+            plainTextBytes = new byte[maxTextBytes];
+            int bytesUsed = 0;
+
+            // Encoder.Convert() won't fail when the byte array is smaller than the size needed to hold the source string,
+            // it will just convert as many characters as possible.
+            Encoding.UTF8.GetEncoder().Convert(copiedText.AsSpan(), plainTextBytes.AsSpan(), true, out _, out bytesUsed, out _);
+
+            encodedString = Convert.ToBase64String(plainTextBytes, 0, bytesUsed).TrimEnd('=');
+
+            // rebuild the toast XML
+            toast = new ToastContentBuilder()
+                .AddArgument("text", encodedString)
+                .AddText("Text Grab")
+                .AddText(toastBody);
+        }
+
+        toast.Show();
     }
 }

--- a/Text-Grab/Views/EditTextWindow.xaml.cs
+++ b/Text-Grab/Views/EditTextWindow.xaml.cs
@@ -89,8 +89,14 @@ public partial class EditTextWindow : Window
             string rawEncodedString = possiblyEndcodedString.Substring(5);
             try
             {
-                byte[] hexEncodedBytes = Convert.FromHexString(rawEncodedString);
-                string copiedText = Encoding.UTF8.GetString(hexEncodedBytes);
+                // restore the padding '=' in base64 string
+                switch (rawEncodedString.Length % 4)
+                {
+                    case 2: rawEncodedString += "=="; break;
+                    case 3: rawEncodedString += "="; break;
+                }
+                byte[] encodedBytes = Convert.FromBase64String(rawEncodedString);
+                string copiedText = Encoding.UTF8.GetString(encodedBytes);
                 PassedTextControl.Text = copiedText;
             }
             catch (Exception ex)


### PR DESCRIPTION
My attempt to fix #198.
- Calculate the length correctly using UTF-8 encoding.
- Truncate toast body text (for display only) first, before truncating the toast launch argument that contains actual data
- Change from hexadecimal to base64 encoding so that more bytes can be stored