### PR TITLE
Support HDR Capture

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -27,7 +27,9 @@
       "PowerShell(Get-ChildItem *)",
       "WebFetch(domain:raw.githubusercontent.com)",
       "Bash(gh issue view *)",
-      "Bash(git log *)"
+      "Bash(git log *)",
+      "Bash(gh pr view *)",
+      "Bash(gh pr diff *)"
     ],
     "deny": []
   }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -26,7 +26,8 @@
       "PowerShell(dotnet test *)",
       "PowerShell(Get-ChildItem *)",
       "WebFetch(domain:raw.githubusercontent.com)",
-      "Bash(gh issue view *)"
+      "Bash(gh issue view *)",
+      "Bash(git log *)"
     ],
     "deny": []
   }

--- a/Tests/HdrToneMapperTests.cs
+++ b/Tests/HdrToneMapperTests.cs
@@ -1,0 +1,91 @@
+using Text_Grab.Utilities.Hdr;
+
+namespace Tests;
+
+public class HdrToneMapperTests
+{
+    [Fact]
+    public void SdrWhiteScaleFromNits_ReferenceWhite_IsOne()
+    {
+        Assert.Equal(1.0, HdrToneMapper.SdrWhiteScaleFromNits(80.0), 5);
+    }
+
+    [Theory]
+    [InlineData(200.0, 2.5)]
+    [InlineData(160.0, 2.0)]
+    [InlineData(480.0, 6.0)]
+    public void SdrWhiteScaleFromNits_ScalesRelativeTo80Nits(double nits, double expectedScale)
+    {
+        Assert.Equal(expectedScale, HdrToneMapper.SdrWhiteScaleFromNits(nits), 5);
+    }
+
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(-5.0)]
+    [InlineData(40.0)]
+    public void SdrWhiteScaleFromNits_NeverBrightens(double nits)
+    {
+        // Values at or below the 80-nit reference must not produce a scale below 1.0,
+        // which would brighten the image instead of correcting the HDR boost.
+        Assert.Equal(1.0, HdrToneMapper.SdrWhiteScaleFromNits(nits), 5);
+    }
+
+    [Fact]
+    public void LinearToSrgb_Endpoints()
+    {
+        Assert.Equal(0.0, HdrToneMapper.LinearToSrgb(0.0), 5);
+        Assert.Equal(1.0, HdrToneMapper.LinearToSrgb(1.0), 5);
+    }
+
+    [Fact]
+    public void ScRgbChannelToSrgbByte_SdrWhiteMapsToFullWhite()
+    {
+        // On a display with SDR white at 200 nits, SDR white sits at scRGB 2.5.
+        double scale = HdrToneMapper.SdrWhiteScaleFromNits(200.0);
+
+        Assert.Equal(255, HdrToneMapper.ScRgbChannelToSrgbByte(2.5, scale));
+    }
+
+    [Fact]
+    public void ScRgbChannelToSrgbByte_UndoesHdrBrightnessBoost()
+    {
+        // The washout bug: SDR content lands above scRGB 1.0 on HDR displays. Normalizing by
+        // the SDR white level must pull mid-gray back to a mid sRGB value rather than near-white.
+        double scale = HdrToneMapper.SdrWhiteScaleFromNits(200.0);
+
+        // Half of SDR white in linear light -> sRGB ~0.735 -> ~188.
+        byte midGray = HdrToneMapper.ScRgbChannelToSrgbByte(1.25, scale);
+        Assert.InRange(midGray, 186, 190);
+    }
+
+    [Fact]
+    public void ScRgbChannelToSrgbByte_HighlightsAboveSdrWhiteClipToWhite()
+    {
+        double scale = HdrToneMapper.SdrWhiteScaleFromNits(200.0);
+
+        // A specular highlight well above SDR white clamps to white rather than overflowing.
+        Assert.Equal(255, HdrToneMapper.ScRgbChannelToSrgbByte(10.0, scale));
+    }
+
+    [Fact]
+    public void ScRgbChannelToSrgbByte_NegativeWideGamutClampsToBlack()
+    {
+        double scale = HdrToneMapper.SdrWhiteScaleFromNits(200.0);
+
+        Assert.Equal(0, HdrToneMapper.ScRgbChannelToSrgbByte(-0.5, scale));
+    }
+
+    [Fact]
+    public void ScRgbChannelToSrgbByte_IsMonotonic()
+    {
+        double scale = HdrToneMapper.SdrWhiteScaleFromNits(200.0);
+        int previous = -1;
+
+        for (double channel = 0.0; channel <= 2.5; channel += 0.05)
+        {
+            int value = HdrToneMapper.ScRgbChannelToSrgbByte(channel, scale);
+            Assert.True(value >= previous, $"Value dropped at channel {channel}");
+            previous = value;
+        }
+    }
+}

--- a/Text-Grab/App.config
+++ b/Text-Grab/App.config
@@ -283,6 +283,12 @@
             <setting name="GrabFrameBorderColor" serializeAs="String">
                 <value>#2A767E</value>
             </setting>
+            <setting name="HdrCaptureCorrection" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="HdrBorderlessGranted" serializeAs="String">
+                <value>False</value>
+            </setting>
         </Text_Grab.Properties.Settings>
     </userSettings>
 </configuration>

--- a/Text-Grab/Pages/GeneralSettings.xaml
+++ b/Text-Grab/Pages/GeneralSettings.xaml
@@ -281,6 +281,35 @@
             Margin="0,16,0,4"
             FontSize="16"
             Style="{StaticResource TextHeader}"
+            Text="HDR Displays" />
+        <StackPanel Orientation="Horizontal">
+            <ui:ToggleSwitch
+                Name="HdrCaptureCorrectionToggle"
+                VerticalAlignment="Center"
+                Checked="HdrCaptureCorrectionToggle_Checked"
+                Unchecked="HdrCaptureCorrectionToggle_Unchecked">
+                <TextBlock Style="{StaticResource TextBodyNormal}">
+                    Correct washed-out captures on HDR displays
+                </TextBlock>
+            </ui:ToggleSwitch>
+            <ui:Button
+                Name="CheckHdrPermissionButton"
+                Margin="16,0,0,0"
+                VerticalAlignment="Center"
+                Click="CheckHdrPermissionButton_Click"
+                Content="Check permissions" />
+        </StackPanel>
+        <TextBlock Style="{StaticResource TextBodyNormal}">
+            Captures HDR screens at full range and tone-maps them back to SDR so text isn't overly bright. Only affects monitors with HDR turned on.
+        </TextBlock>
+        <TextBlock Style="{StaticResource TextBodyNormal}">
+            Removing the yellow capture border needs Windows "borderless capture" permission. Use Check permissions to grant it.
+        </TextBlock>
+
+        <TextBlock
+            Margin="0,16,0,4"
+            FontSize="16"
+            Style="{StaticResource TextHeader}"
             Text="Web Search Options" />
         <ComboBox
             x:Name="WebSearchersComboBox"

--- a/Text-Grab/Pages/GeneralSettings.xaml.cs
+++ b/Text-Grab/Pages/GeneralSettings.xaml.cs
@@ -132,6 +132,7 @@ public partial class GeneralSettings : Page
 
         RunInBackgroundChkBx.IsChecked = DefaultSettings.RunInTheBackground;
         ReadBarcodesBarcode.IsChecked = DefaultSettings.TryToReadBarcodes;
+        HdrCaptureCorrectionToggle.IsChecked = DefaultSettings.HdrCaptureCorrection;
         HistorySwitch.IsChecked = DefaultSettings.UseHistory;
         ErrorCorrectBox.IsChecked = DefaultSettings.CorrectErrors;
         CorrectToLatin.IsChecked = DefaultSettings.CorrectToLatin;
@@ -267,6 +268,54 @@ public partial class GeneralSettings : Page
             return;
 
         DefaultSettings.TryToReadBarcodes = false;
+    }
+
+    private void HdrCaptureCorrectionToggle_Checked(object sender, RoutedEventArgs e)
+    {
+        if (!settingsSet)
+            return;
+
+        DefaultSettings.HdrCaptureCorrection = true;
+    }
+
+    private void HdrCaptureCorrectionToggle_Unchecked(object sender, RoutedEventArgs e)
+    {
+        if (!settingsSet)
+            return;
+
+        DefaultSettings.HdrCaptureCorrection = false;
+    }
+
+    private async void CheckHdrPermissionButton_Click(object sender, RoutedEventArgs e)
+    {
+        CheckHdrPermissionButton.IsEnabled = false;
+
+        Windows.Security.Authorization.AppCapabilityAccess.AppCapabilityAccessStatus status =
+            await Utilities.Hdr.HdrScreenCapture.RequestBorderlessAccessAsync();
+
+        CheckHdrPermissionButton.IsEnabled = true;
+
+        bool allowed = status == Windows.Security.Authorization.AppCapabilityAccess.AppCapabilityAccessStatus.Allowed;
+        DefaultSettings.HdrBorderlessGranted = allowed;
+        DefaultSettings.Save();
+
+        string message = status switch
+        {
+            Windows.Security.Authorization.AppCapabilityAccess.AppCapabilityAccessStatus.Allowed
+                => "Borderless capture is allowed. The yellow capture border will no longer appear.",
+            Windows.Security.Authorization.AppCapabilityAccess.AppCapabilityAccessStatus.DeniedByUser
+                => "Borderless capture was denied. You can allow it in Windows Settings under Privacy & security → Graphics capture (or the consent prompt).",
+            Windows.Security.Authorization.AppCapabilityAccess.AppCapabilityAccessStatus.DeniedBySystem
+                => "Borderless capture is blocked on this system, so the capture border can't be removed.",
+            _ => "Borderless capture permission is currently unavailable.",
+        };
+
+        await new Wpf.Ui.Controls.MessageBox
+        {
+            Title = "HDR Capture Permission",
+            Content = message,
+            CloseButtonText = "OK"
+        }.ShowDialogAsync();
     }
 
     private void HistorySwitch_Checked(object sender, RoutedEventArgs e)

--- a/Text-Grab/Properties/Settings.Designer.cs
+++ b/Text-Grab/Properties/Settings.Designer.cs
@@ -1126,5 +1126,29 @@ namespace Text_Grab.Properties {
                 this["GrabFrameBorderColor"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool HdrCaptureCorrection {
+            get {
+                return ((bool)(this["HdrCaptureCorrection"]));
+            }
+            set {
+                this["HdrCaptureCorrection"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool HdrBorderlessGranted {
+            get {
+                return ((bool)(this["HdrBorderlessGranted"]));
+            }
+            set {
+                this["HdrBorderlessGranted"] = value;
+            }
+        }
     }
 }

--- a/Text-Grab/Properties/Settings.settings
+++ b/Text-Grab/Properties/Settings.settings
@@ -278,5 +278,11 @@
     <Setting Name="GrabFrameBorderColor" Type="System.String" Scope="User">
       <Value Profile="(Default)">#2A767E</Value>
     </Setting>
+    <Setting Name="HdrCaptureCorrection" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="HdrBorderlessGranted" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Text-Grab/Text-Grab.csproj
+++ b/Text-Grab/Text-Grab.csproj
@@ -85,6 +85,8 @@
         <PackageReference Include="NCalcAsync" Version="6.2.0" />
         <PackageReference Include="PdfPig" Version="0.1.14" />
         <PackageReference Include="UnitsNet" Version="5.75.0" />
+        <PackageReference Include="Vortice.Direct3D11" Version="3.8.3" />
+        <PackageReference Include="Vortice.DXGI" Version="3.8.3" />
         <PackageReference Include="WPF-UI" Version="4.3.0" />
         <PackageReference Include="WPF-UI.Tray" Version="4.3.0" />
         <PackageReference Include="ZXing.Net" Version="0.16.11" />

--- a/Text-Grab/Utilities/Hdr/DisplayHdrInfo.cs
+++ b/Text-Grab/Utilities/Hdr/DisplayHdrInfo.cs
@@ -1,0 +1,242 @@
+using System;
+using System.Drawing;
+using System.Runtime.InteropServices;
+using Vortice.DXGI;
+
+namespace Text_Grab.Utilities.Hdr;
+
+/// <summary>
+/// Describes the HDR state of a single monitor as reported by DXGI and the OS display config.
+/// </summary>
+/// <param name="Monitor">The HMONITOR handle, used to create a Windows.Graphics.Capture item.</param>
+/// <param name="DesktopRect">The monitor's bounds in virtual-desktop (physical pixel) coordinates.</param>
+/// <param name="IsHdrActive">True when the monitor is currently outputting an HDR (ST.2084) color space.</param>
+/// <param name="SdrWhiteNits">The SDR reference white level in nits (0 if unknown).</param>
+public readonly record struct MonitorHdrInfo(
+    IntPtr Monitor,
+    Rectangle DesktopRect,
+    bool IsHdrActive,
+    double SdrWhiteNits);
+
+/// <summary>
+/// Queries per-monitor HDR status. Detection uses <c>IDXGIOutput6</c> to read the output's current
+/// color space (so it reflects whether HDR is actually <em>on</em>, not merely supported), and the
+/// Win32 display-config APIs to read the SDR white level needed to tone-map captured frames.
+/// </summary>
+public static class DisplayHdrInfo
+{
+    /// <summary>
+    /// Finds the monitor containing the given virtual-desktop point and returns its HDR info.
+    /// Returns false if no matching output could be enumerated (e.g. remote sessions).
+    /// </summary>
+    public static bool TryGetForPoint(int x, int y, out MonitorHdrInfo info)
+    {
+        info = default;
+
+        try
+        {
+            if (DXGI.CreateDXGIFactory1(out IDXGIFactory1? factory).Failure || factory is null)
+                return false;
+
+            using (factory)
+            {
+                for (uint a = 0; factory.EnumAdapters1(a, out IDXGIAdapter1? adapter).Success && adapter is not null; a++)
+                {
+                    using (adapter)
+                    {
+                        for (uint o = 0; adapter.EnumOutputs(o, out IDXGIOutput? output).Success && output is not null; o++)
+                        {
+                            using (output)
+                            {
+                                using IDXGIOutput6? output6 = output.QueryInterfaceOrNull<IDXGIOutput6>();
+                                if (output6 is null)
+                                    continue;
+
+                                OutputDescription1 desc = output6.Description1;
+                                var coords = desc.DesktopCoordinates;
+                                Rectangle rect = new(
+                                    coords.Left,
+                                    coords.Top,
+                                    coords.Right - coords.Left,
+                                    coords.Bottom - coords.Top);
+
+                                if (!rect.Contains(x, y))
+                                    continue;
+
+                                bool hdrActive = desc.ColorSpace == ColorSpaceType.RgbFullG2084NoneP2020;
+                                double sdrWhite = hdrActive ? GetSdrWhiteNits(desc.DeviceName) : 0;
+
+                                info = new MonitorHdrInfo(desc.Monitor, rect, hdrActive, sdrWhite);
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        catch
+        {
+            // Any failure enumerating adapters means we can't confirm HDR; caller falls back to GDI.
+            return false;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Reads the SDR reference white level (in nits) for the display whose GDI device name is given.
+    /// Returns 0 when it cannot be determined; callers should assume a sensible default in that case.
+    /// </summary>
+    private static double GetSdrWhiteNits(string gdiDeviceName)
+    {
+        try
+        {
+            if (GetDisplayConfigBufferSizes(QDC_ONLY_ACTIVE_PATHS, out uint pathCount, out uint modeCount) != 0)
+                return 0;
+
+            DISPLAYCONFIG_PATH_INFO[] paths = new DISPLAYCONFIG_PATH_INFO[pathCount];
+            DISPLAYCONFIG_MODE_INFO[] modes = new DISPLAYCONFIG_MODE_INFO[modeCount];
+
+            if (QueryDisplayConfig(QDC_ONLY_ACTIVE_PATHS, ref pathCount, paths, ref modeCount, modes, IntPtr.Zero) != 0)
+                return 0;
+
+            for (int i = 0; i < pathCount; i++)
+            {
+                DISPLAYCONFIG_PATH_INFO path = paths[i];
+
+                DISPLAYCONFIG_SOURCE_DEVICE_NAME sourceName = new();
+                sourceName.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_SOURCE_NAME;
+                sourceName.header.size = (uint)Marshal.SizeOf<DISPLAYCONFIG_SOURCE_DEVICE_NAME>();
+                sourceName.header.adapterId = path.sourceInfo.adapterId;
+                sourceName.header.id = path.sourceInfo.id;
+
+                if (DisplayConfigGetDeviceInfo(ref sourceName) != 0)
+                    continue;
+
+                if (!string.Equals(sourceName.viewGdiDeviceName, gdiDeviceName, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                DISPLAYCONFIG_SDR_WHITE_LEVEL whiteLevel = new();
+                whiteLevel.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_SDR_WHITE_LEVEL;
+                whiteLevel.header.size = (uint)Marshal.SizeOf<DISPLAYCONFIG_SDR_WHITE_LEVEL>();
+                whiteLevel.header.adapterId = path.targetInfo.adapterId;
+                whiteLevel.header.id = path.targetInfo.id;
+
+                if (DisplayConfigGetDeviceInfo(ref whiteLevel) == 0 && whiteLevel.SDRWhiteLevel > 0)
+                {
+                    // SDRWhiteLevel is in units of 1/1000th of 80 nits.
+                    return whiteLevel.SDRWhiteLevel / 1000.0 * HdrToneMapper.SdrReferenceWhiteNits;
+                }
+            }
+        }
+        catch
+        {
+            return 0;
+        }
+
+        return 0;
+    }
+
+    #region Display config interop
+
+    private const uint QDC_ONLY_ACTIVE_PATHS = 0x00000002;
+    private const int DISPLAYCONFIG_DEVICE_INFO_GET_SOURCE_NAME = 1;
+    private const int DISPLAYCONFIG_DEVICE_INFO_GET_SDR_WHITE_LEVEL = 11;
+
+    [DllImport("user32.dll")]
+    private static extern int GetDisplayConfigBufferSizes(uint flags, out uint numPathArrayElements, out uint numModeInfoArrayElements);
+
+    [DllImport("user32.dll")]
+    private static extern int QueryDisplayConfig(
+        uint flags,
+        ref uint numPathArrayElements,
+        [Out] DISPLAYCONFIG_PATH_INFO[] pathArray,
+        ref uint numModeInfoArrayElements,
+        [Out] DISPLAYCONFIG_MODE_INFO[] modeInfoArray,
+        IntPtr currentTopologyId);
+
+    [DllImport("user32.dll")]
+    private static extern int DisplayConfigGetDeviceInfo(ref DISPLAYCONFIG_SOURCE_DEVICE_NAME requestPacket);
+
+    [DllImport("user32.dll")]
+    private static extern int DisplayConfigGetDeviceInfo(ref DISPLAYCONFIG_SDR_WHITE_LEVEL requestPacket);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct LUID
+    {
+        public uint LowPart;
+        public int HighPart;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct DISPLAYCONFIG_RATIONAL
+    {
+        public uint Numerator;
+        public uint Denominator;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct DISPLAYCONFIG_PATH_SOURCE_INFO
+    {
+        public LUID adapterId;
+        public uint id;
+        public uint modeInfoIdx;
+        public uint statusFlags;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct DISPLAYCONFIG_PATH_TARGET_INFO
+    {
+        public LUID adapterId;
+        public uint id;
+        public uint modeInfoIdx;
+        public int outputTechnology;
+        public int rotation;
+        public int scaling;
+        public DISPLAYCONFIG_RATIONAL refreshRate;
+        public int scanLineOrdering;
+        public int targetAvailable;
+        public uint statusFlags;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct DISPLAYCONFIG_PATH_INFO
+    {
+        public DISPLAYCONFIG_PATH_SOURCE_INFO sourceInfo;
+        public DISPLAYCONFIG_PATH_TARGET_INFO targetInfo;
+        public uint flags;
+    }
+
+    // The mode info union is 64 bytes total; we never read its contents, only pass the buffer through.
+    [StructLayout(LayoutKind.Sequential, Size = 64)]
+    private struct DISPLAYCONFIG_MODE_INFO
+    {
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct DISPLAYCONFIG_DEVICE_INFO_HEADER
+    {
+        public int type;
+        public uint size;
+        public LUID adapterId;
+        public uint id;
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct DISPLAYCONFIG_SOURCE_DEVICE_NAME
+    {
+        public DISPLAYCONFIG_DEVICE_INFO_HEADER header;
+
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)]
+        public string viewGdiDeviceName;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct DISPLAYCONFIG_SDR_WHITE_LEVEL
+    {
+        public DISPLAYCONFIG_DEVICE_INFO_HEADER header;
+        public uint SDRWhiteLevel;
+    }
+
+    #endregion
+}

--- a/Text-Grab/Utilities/Hdr/HdrScreenCapture.cs
+++ b/Text-Grab/Utilities/Hdr/HdrScreenCapture.cs
@@ -1,0 +1,377 @@
+using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Vortice.Direct3D;
+using Vortice.Direct3D11;
+using Vortice.DXGI;
+using Windows.Graphics.Capture;
+using Windows.Graphics.DirectX;
+using Windows.Graphics.DirectX.Direct3D11;
+using WinRT;
+using PixelFormat = System.Drawing.Imaging.PixelFormat;
+
+namespace Text_Grab.Utilities.Hdr;
+
+/// <summary>
+/// Captures a screen region from an HDR display using Windows.Graphics.Capture at full FP16
+/// (scRGB) precision, then tone-maps it down to an SDR <see cref="Bitmap"/>. Capturing before
+/// the pixels are quantized to 8-bit is what lets us undo the HDR brightness boost that makes
+/// GDI screenshots look washed out (issue #111).
+///
+/// All methods return null (rather than throwing) when the region is not on an HDR display or
+/// when any part of the capture pipeline is unavailable, so callers can fall back to GDI.
+/// </summary>
+public static class HdrScreenCapture
+{
+    private static readonly Guid ID3D11Texture2DGuid = new("6f15aaf2-d208-4e89-9ab4-489535d34f9c");
+
+    // Reasonable default when the OS won't report the SDR white level; matches the typical
+    // Windows "SDR content brightness" default so the correction is close even without it.
+    private const double FallbackSdrWhiteNits = 200.0;
+
+    private const int FrameTimeoutMilliseconds = 1000;
+
+    /// <summary>
+    /// Attempts to capture the given virtual-desktop region as an SDR bitmap using HDR-aware
+    /// capture. Returns null if the region is not on an HDR-active display or capture fails.
+    /// </summary>
+    public static Bitmap? TryCaptureRegion(Rectangle region)
+    {
+        if (region.Width <= 0 || region.Height <= 0)
+            return null;
+
+        if (!GraphicsCaptureSession.IsSupported())
+            return null;
+
+        int centerX = region.Left + region.Width / 2;
+        int centerY = region.Top + region.Height / 2;
+
+        if (!DisplayHdrInfo.TryGetForPoint(centerX, centerY, out MonitorHdrInfo monitor) || !monitor.IsHdrActive)
+            return null;
+
+        try
+        {
+            return CaptureHdrRegion(region, monitor);
+        }
+        catch
+        {
+            // Any failure in the HDR pipeline: let the caller fall back to the GDI capture.
+            return null;
+        }
+    }
+
+    private static Bitmap? CaptureHdrRegion(Rectangle region, MonitorHdrInfo monitor)
+    {
+        FeatureLevel[] featureLevels =
+        [
+            FeatureLevel.Level_11_1,
+            FeatureLevel.Level_11_0,
+            FeatureLevel.Level_10_1,
+            FeatureLevel.Level_10_0,
+        ];
+
+        if (D3D11.D3D11CreateDevice(null, DriverType.Hardware, DeviceCreationFlags.BgraSupport, featureLevels, out ID3D11Device? d3dDevice).Failure
+            || d3dDevice is null)
+        {
+            return null;
+        }
+
+        using (d3dDevice)
+        using (ID3D11DeviceContext context = d3dDevice.ImmediateContext)
+        {
+            IDirect3DDevice? winrtDevice = CreateWinRtDevice(d3dDevice);
+            if (winrtDevice is null)
+                return null;
+
+            GraphicsCaptureItem? item = CreateItemForMonitor(monitor.Monitor);
+            if (item is null)
+                return null;
+
+            Direct3D11CaptureFramePool framePool = Direct3D11CaptureFramePool.CreateFreeThreaded(
+                winrtDevice,
+                DirectXPixelFormat.R16G16B16A16Float,
+                1,
+                item.Size);
+
+            GraphicsCaptureSession session = framePool.CreateCaptureSession(item);
+            TrySet(() => session.IsCursorCaptureEnabled = false);
+
+            // The yellow/orange capture border is only removable once the app has been granted
+            // "borderless" capture access; setting IsBorderRequired without it throws. The access
+            // request must never block the capture thread (it may show a consent dialog that needs
+            // the UI pump), so we only disable the border when access has already been granted and
+            // otherwise kick off a one-time, non-blocking request that self-heals on later captures.
+            if (_borderlessGranted)
+                TrySet(() => session.IsBorderRequired = false);
+            else
+                EnsureBorderlessRequestedOnce();
+
+            using ManualResetEventSlim frameReady = new(false);
+            Direct3D11CaptureFrame? frame = null;
+
+            void OnFrameArrived(Direct3D11CaptureFramePool sender, object args)
+            {
+                if (frame is not null)
+                    return;
+
+                frame = sender.TryGetNextFrame();
+                if (frame is not null)
+                    frameReady.Set();
+            }
+
+            framePool.FrameArrived += OnFrameArrived;
+
+            try
+            {
+                session.StartCapture();
+
+                if (!frameReady.Wait(FrameTimeoutMilliseconds) || frame is null)
+                    return null;
+
+                return ToneMapFrameToBitmap(frame, region, monitor, d3dDevice, context);
+            }
+            finally
+            {
+                framePool.FrameArrived -= OnFrameArrived;
+                frame?.Dispose();
+                session.Dispose();
+                framePool.Dispose();
+                item = null;
+                winrtDevice.Dispose();
+            }
+        }
+    }
+
+    private static Bitmap? ToneMapFrameToBitmap(
+        Direct3D11CaptureFrame frame,
+        Rectangle region,
+        MonitorHdrInfo monitor,
+        ID3D11Device d3dDevice,
+        ID3D11DeviceContext context)
+    {
+        using ID3D11Texture2D sourceTexture = GetTexture(frame.Surface);
+
+        Texture2DDescription desc = sourceTexture.Description;
+        int textureWidth = (int)desc.Width;
+        int textureHeight = (int)desc.Height;
+
+        desc.Usage = ResourceUsage.Staging;
+        desc.BindFlags = BindFlags.None;
+        desc.CPUAccessFlags = CpuAccessFlags.Read;
+        desc.MiscFlags = ResourceOptionFlags.None;
+
+        using ID3D11Texture2D staging = d3dDevice.CreateTexture2D(desc);
+        context.CopyResource(staging, sourceTexture);
+
+        MappedSubresource map = context.Map(staging, 0, MapMode.Read, Vortice.Direct3D11.MapFlags.None);
+        try
+        {
+            double sdrWhiteNits = monitor.SdrWhiteNits > 0 ? monitor.SdrWhiteNits : FallbackSdrWhiteNits;
+            double sdrWhiteScale = HdrToneMapper.SdrWhiteScaleFromNits(sdrWhiteNits);
+
+            int offsetX = region.Left - monitor.DesktopRect.Left;
+            int offsetY = region.Top - monitor.DesktopRect.Top;
+
+            Bitmap bmp = new(region.Width, region.Height, PixelFormat.Format32bppArgb);
+            BitmapData data = bmp.LockBits(
+                new Rectangle(0, 0, region.Width, region.Height),
+                ImageLockMode.WriteOnly,
+                PixelFormat.Format32bppArgb);
+
+            try
+            {
+                unsafe
+                {
+                    byte* sourceBase = (byte*)map.DataPointer;
+
+                    for (int y = 0; y < region.Height; y++)
+                    {
+                        byte* destRow = (byte*)data.Scan0 + (long)y * data.Stride;
+                        int sourceY = offsetY + y;
+
+                        if (sourceY < 0 || sourceY >= textureHeight)
+                            continue;
+
+                        ushort* sourceRow = (ushort*)(sourceBase + (long)sourceY * map.RowPitch);
+
+                        for (int x = 0; x < region.Width; x++)
+                        {
+                            byte* destPixel = destRow + x * 4;
+                            int sourceX = offsetX + x;
+
+                            if (sourceX < 0 || sourceX >= textureWidth)
+                            {
+                                destPixel[3] = 255;
+                                continue;
+                            }
+
+                            ushort* sourcePixel = sourceRow + sourceX * 4;
+                            double r = (float)BitConverter.UInt16BitsToHalf(sourcePixel[0]);
+                            double g = (float)BitConverter.UInt16BitsToHalf(sourcePixel[1]);
+                            double b = (float)BitConverter.UInt16BitsToHalf(sourcePixel[2]);
+
+                            // System.Drawing 32bppArgb is stored BGRA in memory.
+                            destPixel[0] = HdrToneMapper.ScRgbChannelToSrgbByte(b, sdrWhiteScale);
+                            destPixel[1] = HdrToneMapper.ScRgbChannelToSrgbByte(g, sdrWhiteScale);
+                            destPixel[2] = HdrToneMapper.ScRgbChannelToSrgbByte(r, sdrWhiteScale);
+                            destPixel[3] = 255;
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                bmp.UnlockBits(data);
+            }
+
+            return bmp;
+        }
+        finally
+        {
+            context.Unmap(staging, 0);
+        }
+    }
+
+    private static ID3D11Texture2D GetTexture(IDirect3DSurface surface)
+    {
+        IDirect3DDxgiInterfaceAccess access = surface.As<IDirect3DDxgiInterfaceAccess>();
+        Guid guid = ID3D11Texture2DGuid;
+        IntPtr texturePointer = access.GetInterface(ref guid);
+        return new ID3D11Texture2D(texturePointer);
+    }
+
+    private static IDirect3DDevice? CreateWinRtDevice(ID3D11Device d3dDevice)
+    {
+        using IDXGIDevice dxgiDevice = d3dDevice.QueryInterface<IDXGIDevice>();
+
+        if (CreateDirect3D11DeviceFromDXGIDevice(dxgiDevice.NativePointer, out IntPtr graphicsDevice) != 0)
+            return null;
+
+        try
+        {
+            return MarshalInterface<IDirect3DDevice>.FromAbi(graphicsDevice);
+        }
+        finally
+        {
+            Marshal.Release(graphicsDevice);
+        }
+    }
+
+    private static GraphicsCaptureItem? CreateItemForMonitor(IntPtr hmon)
+    {
+        if (hmon == IntPtr.Zero)
+            return null;
+
+        IGraphicsCaptureItemInterop interop = ActivationFactory
+            .Get("Windows.Graphics.Capture.GraphicsCaptureItem")
+            .AsInterface<IGraphicsCaptureItemInterop>();
+
+        Guid guid = GraphicsCaptureItemGuid;
+        IntPtr itemPointer = interop.CreateForMonitor(hmon, ref guid);
+
+        try
+        {
+            return GraphicsCaptureItem.FromAbi(itemPointer);
+        }
+        finally
+        {
+            Marshal.Release(itemPointer);
+        }
+    }
+
+    private static void TrySet(Action action)
+    {
+        try
+        {
+            action();
+        }
+        catch
+        {
+            // Property not supported on this OS build; ignore.
+        }
+    }
+
+    private static volatile bool _borderlessGranted;
+    private static int _borderlessRequestStarted;
+
+    /// <summary>
+    /// True once the OS has granted this process permission to capture without the capture border.
+    /// </summary>
+    public static bool IsBorderlessGranted => _borderlessGranted;
+
+    /// <summary>
+    /// Requests permission to capture without the OS-drawn capture border. May show a one-time
+    /// consent dialog, so this must be awaited from the UI thread (e.g. a settings button), never
+    /// from the capture path. Returns the resulting access status.
+    /// </summary>
+    public static async System.Threading.Tasks.Task<Windows.Security.Authorization.AppCapabilityAccess.AppCapabilityAccessStatus> RequestBorderlessAccessAsync()
+    {
+        // Mark as started so the capture path won't also fire a duplicate request.
+        System.Threading.Interlocked.Exchange(ref _borderlessRequestStarted, 1);
+
+        try
+        {
+            Windows.Security.Authorization.AppCapabilityAccess.AppCapabilityAccessStatus status =
+                await GraphicsCaptureAccess.RequestAccessAsync(GraphicsCaptureAccessKind.Borderless);
+
+            _borderlessGranted = status == Windows.Security.Authorization.AppCapabilityAccess.AppCapabilityAccessStatus.Allowed;
+            return status;
+        }
+        catch
+        {
+            _borderlessGranted = false;
+            return Windows.Security.Authorization.AppCapabilityAccess.AppCapabilityAccessStatus.DeniedBySystem;
+        }
+    }
+
+    /// <summary>
+    /// Fires a single non-blocking borderless-access request on the UI thread. When the user has
+    /// already consented in a previous session the request completes silently and later captures
+    /// drop the border automatically; otherwise the border stays until the user grants access.
+    /// </summary>
+    private static void EnsureBorderlessRequestedOnce()
+    {
+        // Only silently re-activate for users who already granted access in a past session, so a
+        // consent prompt never appears unexpectedly during a grab. First-time consent is explicit,
+        // via the "Check permissions" button in settings.
+        if (!AppUtilities.TextGrabSettings.HdrBorderlessGranted)
+            return;
+
+        if (System.Threading.Interlocked.Exchange(ref _borderlessRequestStarted, 1) != 0)
+            return;
+
+        System.Windows.Threading.Dispatcher? dispatcher = System.Windows.Application.Current?.Dispatcher;
+        if (dispatcher is null)
+            return;
+
+        _ = dispatcher.InvokeAsync(async () => await RequestBorderlessAccessAsync());
+    }
+
+    #region WinRT / D3D interop
+
+    [DllImport("d3d11.dll", EntryPoint = "CreateDirect3D11DeviceFromDXGIDevice", SetLastError = true)]
+    private static extern uint CreateDirect3D11DeviceFromDXGIDevice(IntPtr dxgiDevice, out IntPtr graphicsDevice);
+
+    private static readonly Guid GraphicsCaptureItemGuid = new("79C3F95B-31F7-4EC2-A464-632EF5D30760");
+
+    [ComImport]
+    [Guid("A9B3D012-3DF2-4EE3-B8D1-8695F457D3C1")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    private interface IDirect3DDxgiInterfaceAccess
+    {
+        IntPtr GetInterface([In] ref Guid iid);
+    }
+
+    [ComImport]
+    [Guid("3628E81B-3CAC-4C60-B7F4-23CE0E0C3356")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    private interface IGraphicsCaptureItemInterop
+    {
+        IntPtr CreateForWindow([In] IntPtr window, [In] ref Guid iid);
+        IntPtr CreateForMonitor([In] IntPtr monitor, [In] ref Guid iid);
+    }
+
+    #endregion
+}

--- a/Text-Grab/Utilities/Hdr/HdrScreenCapture.cs
+++ b/Text-Grab/Utilities/Hdr/HdrScreenCapture.cs
@@ -31,7 +31,20 @@ public static class HdrScreenCapture
     // Windows "SDR content brightness" default so the correction is close even without it.
     private const double FallbackSdrWhiteNits = 200.0;
 
-    private const int FrameTimeoutMilliseconds = 1000;
+    // Bounded so a capture that never receives a frame (e.g. WGC not delivering one for fully
+    // static content) falls back to GDI quickly instead of stalling the calling thread — which is
+    // often the UI thread. A healthy capture delivers its first frame within a few refresh
+    // intervals, so this still leaves ample margin.
+    private const int FrameTimeoutMilliseconds = 250;
+
+    private static readonly object _captureLock = new();
+
+    // The D3D11 device, its immediate context, and the WinRT device projection are expensive to
+    // create, so they are built once and reused across captures. A failed capture disposes them via
+    // DisposeSharedDevice so the next call rebuilds a fresh device, which also recovers a lost one.
+    private static ID3D11Device? _sharedDevice;
+    private static ID3D11DeviceContext? _sharedContext;
+    private static IDirect3DDevice? _sharedWinRtDevice;
 
     /// <summary>
     /// Attempts to capture the given virtual-desktop region as an SDR bitmap using HDR-aware
@@ -51,19 +64,105 @@ public static class HdrScreenCapture
         if (!DisplayHdrInfo.TryGetForPoint(centerX, centerY, out MonitorHdrInfo monitor) || !monitor.IsHdrActive)
             return null;
 
-        try
+        lock (_captureLock)
         {
-            return CaptureHdrRegion(region, monitor);
-        }
-        catch
-        {
-            // Any failure in the HDR pipeline: let the caller fall back to the GDI capture.
-            return null;
+            try
+            {
+                return CaptureHdrRegion(region, monitor);
+            }
+            catch
+            {
+                // Any failure in the HDR pipeline (including a lost device): drop the shared device
+                // so the next capture rebuilds it, and let the caller fall back to the GDI capture.
+                DisposeSharedDevice();
+                return null;
+            }
         }
     }
 
     private static Bitmap? CaptureHdrRegion(Rectangle region, MonitorHdrInfo monitor)
     {
+        if (!TryGetSharedDevice(out ID3D11Device d3dDevice, out ID3D11DeviceContext context, out IDirect3DDevice winrtDevice))
+            return null;
+
+        GraphicsCaptureItem? item = CreateItemForMonitor(monitor.Monitor);
+        if (item is null)
+            return null;
+
+        Direct3D11CaptureFramePool framePool = Direct3D11CaptureFramePool.CreateFreeThreaded(
+            winrtDevice,
+            DirectXPixelFormat.R16G16B16A16Float,
+            1,
+            item.Size);
+
+        GraphicsCaptureSession session = framePool.CreateCaptureSession(item);
+        TrySet(() => session.IsCursorCaptureEnabled = false);
+
+        // The yellow/orange capture border is only removable once the app has been granted
+        // "borderless" capture access; setting IsBorderRequired without it throws. The access
+        // request must never block the capture thread (it may show a consent dialog that needs
+        // the UI pump), so we only disable the border when access has already been granted and
+        // otherwise kick off a one-time, non-blocking request that self-heals on later captures.
+        if (_borderlessGranted)
+            TrySet(() => session.IsBorderRequired = false);
+        else
+            EnsureBorderlessRequestedOnce();
+
+        using ManualResetEventSlim frameReady = new(false);
+        Direct3D11CaptureFrame? frame = null;
+
+        void OnFrameArrived(Direct3D11CaptureFramePool sender, object args)
+        {
+            if (frame is not null)
+                return;
+
+            frame = sender.TryGetNextFrame();
+            if (frame is not null)
+                frameReady.Set();
+        }
+
+        framePool.FrameArrived += OnFrameArrived;
+
+        try
+        {
+            session.StartCapture();
+
+            if (!frameReady.Wait(FrameTimeoutMilliseconds) || frame is null)
+                return null;
+
+            return ToneMapFrameToBitmap(frame, region, monitor, d3dDevice, context);
+        }
+        finally
+        {
+            framePool.FrameArrived -= OnFrameArrived;
+            frame?.Dispose();
+            session.Dispose();
+            framePool.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Returns the process-wide D3D11 device, its immediate context, and the WinRT device
+    /// projection, creating them on first use and reusing them on later captures. Every caller runs
+    /// under <see cref="_captureLock"/>, so the shared immediate context is only ever touched by one
+    /// capture at a time. Returns false if a device could not be created.
+    /// </summary>
+    private static bool TryGetSharedDevice(out ID3D11Device device, out ID3D11DeviceContext context, out IDirect3DDevice winrtDevice)
+    {
+        if (_sharedDevice is not null && _sharedContext is not null && _sharedWinRtDevice is not null)
+        {
+            device = _sharedDevice;
+            context = _sharedContext;
+            winrtDevice = _sharedWinRtDevice;
+            return true;
+        }
+
+        DisposeSharedDevice();
+
+        device = null!;
+        context = null!;
+        winrtDevice = null!;
+
         FeatureLevel[] featureLevels =
         [
             FeatureLevel.Level_11_1,
@@ -72,76 +171,41 @@ public static class HdrScreenCapture
             FeatureLevel.Level_10_0,
         ];
 
-        if (D3D11.D3D11CreateDevice(null, DriverType.Hardware, DeviceCreationFlags.BgraSupport, featureLevels, out ID3D11Device? d3dDevice).Failure
-            || d3dDevice is null)
+        if (D3D11.D3D11CreateDevice(null, DriverType.Hardware, DeviceCreationFlags.BgraSupport, featureLevels, out ID3D11Device? created).Failure
+            || created is null)
         {
-            return null;
+            return false;
         }
 
-        using (d3dDevice)
-        using (ID3D11DeviceContext context = d3dDevice.ImmediateContext)
+        IDirect3DDevice? winrt = CreateWinRtDevice(created);
+        if (winrt is null)
         {
-            IDirect3DDevice? winrtDevice = CreateWinRtDevice(d3dDevice);
-            if (winrtDevice is null)
-                return null;
-
-            GraphicsCaptureItem? item = CreateItemForMonitor(monitor.Monitor);
-            if (item is null)
-                return null;
-
-            Direct3D11CaptureFramePool framePool = Direct3D11CaptureFramePool.CreateFreeThreaded(
-                winrtDevice,
-                DirectXPixelFormat.R16G16B16A16Float,
-                1,
-                item.Size);
-
-            GraphicsCaptureSession session = framePool.CreateCaptureSession(item);
-            TrySet(() => session.IsCursorCaptureEnabled = false);
-
-            // The yellow/orange capture border is only removable once the app has been granted
-            // "borderless" capture access; setting IsBorderRequired without it throws. The access
-            // request must never block the capture thread (it may show a consent dialog that needs
-            // the UI pump), so we only disable the border when access has already been granted and
-            // otherwise kick off a one-time, non-blocking request that self-heals on later captures.
-            if (_borderlessGranted)
-                TrySet(() => session.IsBorderRequired = false);
-            else
-                EnsureBorderlessRequestedOnce();
-
-            using ManualResetEventSlim frameReady = new(false);
-            Direct3D11CaptureFrame? frame = null;
-
-            void OnFrameArrived(Direct3D11CaptureFramePool sender, object args)
-            {
-                if (frame is not null)
-                    return;
-
-                frame = sender.TryGetNextFrame();
-                if (frame is not null)
-                    frameReady.Set();
-            }
-
-            framePool.FrameArrived += OnFrameArrived;
-
-            try
-            {
-                session.StartCapture();
-
-                if (!frameReady.Wait(FrameTimeoutMilliseconds) || frame is null)
-                    return null;
-
-                return ToneMapFrameToBitmap(frame, region, monitor, d3dDevice, context);
-            }
-            finally
-            {
-                framePool.FrameArrived -= OnFrameArrived;
-                frame?.Dispose();
-                session.Dispose();
-                framePool.Dispose();
-                item = null;
-                winrtDevice.Dispose();
-            }
+            created.Dispose();
+            return false;
         }
+
+        _sharedDevice = created;
+        _sharedContext = created.ImmediateContext;
+        _sharedWinRtDevice = winrt;
+
+        device = _sharedDevice;
+        context = _sharedContext;
+        winrtDevice = _sharedWinRtDevice;
+        return true;
+    }
+
+    /// <summary>
+    /// Disposes and clears the cached device, context, and WinRT device so the next capture rebuilds
+    /// a fresh device. Called after a capture failure, which also recovers from a lost device.
+    /// </summary>
+    private static void DisposeSharedDevice()
+    {
+        _sharedWinRtDevice?.Dispose();
+        _sharedWinRtDevice = null;
+        _sharedContext?.Dispose();
+        _sharedContext = null;
+        _sharedDevice?.Dispose();
+        _sharedDevice = null;
     }
 
     private static Bitmap? ToneMapFrameToBitmap(

--- a/Text-Grab/Utilities/Hdr/HdrToneMapper.cs
+++ b/Text-Grab/Utilities/Hdr/HdrToneMapper.cs
@@ -1,0 +1,62 @@
+using System;
+
+namespace Text_Grab.Utilities.Hdr;
+
+/// <summary>
+/// Pure, side-effect-free helpers that convert HDR (scRGB, FP16) pixel values captured
+/// from an HDR display down to standard 8-bit sRGB values.
+///
+/// Windows composites the desktop in scRGB when HDR is enabled: values are linear and
+/// unbounded, where 1.0 corresponds to the sRGB reference white of 80 nits. The user's
+/// "SDR content brightness" slider pushes SDR white well above 80 nits, so ordinary
+/// (non-HDR) content lands at scRGB values greater than 1.0. A naive capture keeps that
+/// boost, which is why HDR screenshots come out washed out / too bright (see issue #111).
+///
+/// The fix is to divide by the display's actual SDR white level so SDR content maps back
+/// to 1.0, then encode with the sRGB transfer function. HDR highlights above SDR white
+/// clip to white, matching how the same content looks with HDR turned off.
+/// </summary>
+public static class HdrToneMapper
+{
+    /// <summary>scRGB value 1.0 equals the sRGB reference white of 80 nits.</summary>
+    public const double SdrReferenceWhiteNits = 80.0;
+
+    /// <summary>
+    /// Converts a display SDR white level (in nits) to the scRGB value at which SDR white sits.
+    /// Clamped so the scale is never below 1.0 (80 nits), which would brighten rather than
+    /// correct the image.
+    /// </summary>
+    public static double SdrWhiteScaleFromNits(double sdrWhiteNits)
+    {
+        double nits = sdrWhiteNits > 0 ? sdrWhiteNits : SdrReferenceWhiteNits;
+        return Math.Max(nits, SdrReferenceWhiteNits) / SdrReferenceWhiteNits;
+    }
+
+    /// <summary>
+    /// Maps a single linear scRGB channel value to an 8-bit sRGB value.
+    /// </summary>
+    /// <param name="channel">Linear scRGB channel value (may be negative for wide-gamut colors or above 1.0 for HDR highlights).</param>
+    /// <param name="sdrWhiteScale">scRGB value of SDR white, from <see cref="SdrWhiteScaleFromNits"/>.</param>
+    public static byte ScRgbChannelToSrgbByte(double channel, double sdrWhiteScale)
+    {
+        if (sdrWhiteScale <= 0)
+            sdrWhiteScale = 1.0;
+
+        // Normalize so SDR white becomes 1.0, then clamp: negatives (outside sRGB gamut)
+        // go to 0 and HDR highlights above SDR white clip to white.
+        double normalized = Math.Clamp(channel / sdrWhiteScale, 0.0, 1.0);
+        double srgb = LinearToSrgb(normalized);
+        return (byte)Math.Clamp((int)(srgb * 255.0 + 0.5), 0, 255);
+    }
+
+    /// <summary>
+    /// Applies the sRGB transfer function (opto-electronic) to a linear value in [0, 1].
+    /// </summary>
+    public static double LinearToSrgb(double value)
+    {
+        if (value <= 0.0031308)
+            return 12.92 * value;
+
+        return 1.055 * Math.Pow(value, 1.0 / 2.4) - 0.055;
+    }
+}

--- a/Text-Grab/Utilities/ImageMethods.cs
+++ b/Text-Grab/Utilities/ImageMethods.cs
@@ -8,6 +8,7 @@ using System.Windows.Media.Imaging;
 using Text_Grab.Extensions;
 using Text_Grab.Services;
 using Text_Grab.Utilities;
+using Text_Grab.Utilities.Hdr;
 using Text_Grab.Views;
 using Windows.Storage.Streams;
 using BitmapEncoder = System.Windows.Media.Imaging.BitmapEncoder;
@@ -90,12 +91,31 @@ public static class ImageMethods
         return bitmapImage;
     }
 
-    public static Bitmap GetRegionOfScreenAsBitmap(Rectangle region, bool cacheResult = true)
+    /// <summary>
+    /// Captures a virtual-desktop region to a bitmap. When the region lives on an HDR display
+    /// and HDR correction is enabled, this uses Windows.Graphics.Capture to grab the frame at
+    /// full precision and tone-map it back to SDR so the result isn't washed out (issue #111).
+    /// Falls back to a plain GDI screen copy otherwise or if HDR capture fails.
+    /// </summary>
+    private static Bitmap CaptureScreenRegion(Rectangle region)
     {
+        if (AppUtilities.TextGrabSettings.HdrCaptureCorrection)
+        {
+            Bitmap? hdrBitmap = HdrScreenCapture.TryCaptureRegion(region);
+            if (hdrBitmap is not null)
+                return hdrBitmap;
+        }
+
         Bitmap bmp = new(region.Width, region.Height, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
         using Graphics g = Graphics.FromImage(bmp);
 
         g.CopyFromScreen(region.Left, region.Top, 0, 0, bmp.Size, CopyPixelOperation.SourceCopy);
+        return bmp;
+    }
+
+    public static Bitmap GetRegionOfScreenAsBitmap(Rectangle region, bool cacheResult = true)
+    {
+        Bitmap bmp = CaptureScreenRegion(region);
         bmp = PadImage(bmp);
 
         if (cacheResult)
@@ -141,11 +161,8 @@ public static class ImageMethods
             }
         }
 
-        Bitmap bmp = new(windowWidth, windowHeight, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
-        using Graphics g = Graphics.FromImage(bmp);
-
-        g.CopyFromScreen(thisCorrectedLeft, thisCorrectedTop, 0, 0, bmp.Size, CopyPixelOperation.SourceCopy);
-        return bmp;
+        Rectangle windowRegion = new(thisCorrectedLeft, thisCorrectedTop, windowWidth, windowHeight);
+        return CaptureScreenRegion(windowRegion);
     }
 
     public static ImageSource GetWindowBoundsImage(Window passedWindow)


### PR DESCRIPTION
#### PR Classification
New feature and bug fix to support accurate screen capture on HDR displays and resolve washed-out screenshot issues.

#### PR Summary
This PR adds HDR-aware screen capture and tone-mapping to correct brightness on HDR monitors, introduces user settings for HDR correction, and provides unit tests for the new logic.
- Added `DisplayHdrInfo`, `HdrScreenCapture`, and `HdrToneMapper` classes in Text_Grab.Utilities.Hdr for HDR detection, capture, and tone-mapping.
- Updated `ImageMethods` to use HDR capture and tone-mapping when enabled.
- Enhanced `GeneralSettings.xaml` and `GeneralSettings.xaml.cs` with HDR correction toggles and borderless capture permission UI.
- Registered new HDR-related settings in App.config, Settings.settings, and Settings.Designer.cs.
- Added unit tests for tone-mapping in `HdrToneMapperTests.cs`.

Closes #111 