### PR TITLE
Fix Latin correction for non-Latin OCR languages

### DIFF
--- a/Tests/LanguageTests.cs
+++ b/Tests/LanguageTests.cs
@@ -33,6 +33,8 @@ public class LanguageTests
     [InlineData("it-IT")]
     [InlineData("ro-RO")]
     [InlineData("pt-BR")]
+    [InlineData("de-DE")]
+    [InlineData("nl-NL")]
     public void IsLatinBased_WithLatinLanguages_ReturnsTrue(string languageTag)
     {
         // Arrange
@@ -46,6 +48,16 @@ public class LanguageTests
         // Assert
         Assert.True(result);
         Assert.True(tessResult);
+    }
+
+    [Theory]
+    [InlineData("deu", true)]
+    [InlineData("nld", true)]
+    [InlineData("rus", false)]
+    [InlineData("ara", false)]
+    public void IsLatinBased_WithTesseractLanguages_UsesResolvedScript(string languageTag, bool expected)
+    {
+        Assert.Equal(expected, new TessLang(languageTag).IsLatinBased());
     }
 
     [Theory]

--- a/Tests/OcrTests.cs
+++ b/Tests/OcrTests.cs
@@ -33,6 +33,7 @@ Bookman-Demi
 ";
 
     private const string fontTestPath = @".\Images\FontTest.png";
+
     private const string fontTestResult = @"Arial
 Times New Roman
 Georgia
@@ -102,6 +103,37 @@ REVENUES OVERY(UNDER) EXPENDITURES	$9,749	$0	$9,749	N/A";
 た
 によくないです。少しすつ食べましよう。
 """;
+
+    [Theory]
+    [InlineData("en-US", "H3llO")]
+    [InlineData("ru-RU", "HЭllΘ")]
+    public void CleanOutput_CorrectsOnlyLatinCaptureLanguages(string languageTag, string expected)
+    {
+        Settings settings = AppUtilities.TextGrabSettings;
+        bool originalCorrectToLatin = settings.CorrectToLatin;
+        bool originalCorrectErrors = settings.CorrectErrors;
+        settings.CorrectToLatin = true;
+        settings.CorrectErrors = false;
+
+        try
+        {
+            OcrOutput output = new()
+            {
+                Kind = OcrOutputKind.Paragraph,
+                Language = new GlobalLang(languageTag),
+                RawOutput = "HЭllΘ"
+            };
+
+            output.CleanOutput();
+
+            Assert.Equal(expected, output.CleanedOutput);
+        }
+        finally
+        {
+            settings.CorrectToLatin = originalCorrectToLatin;
+            settings.CorrectErrors = originalCorrectErrors;
+        }
+    }
 
     [WpfFact]
     public async Task OcrFontSampleImage()

--- a/Text-Grab/Extensions/LanguageExtensions.cs
+++ b/Text-Grab/Extensions/LanguageExtensions.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Windows.Markup;
 using Text_Grab.Interfaces;
 using Text_Grab.Models;
@@ -47,20 +45,7 @@ public static class LanguageExtensions
 
     public static bool IsLatinBased(this ILanguage selectedLanguage)
     {
-        // List of Latin-based languages
-        List<string> LatinLanguages =
-        [
-            "en",  // English
-            "es",  // Spanish
-            "fr",  // French
-            "it",  // Italian
-            "ro",  // Romanian
-            "pt"   // Portuguese
-        ];
-
-        string languageTag = selectedLanguage.LanguageTag;
-
-        return LatinLanguages.Any(lang => languageTag.StartsWith(lang, StringComparison.InvariantCultureIgnoreCase));
+        return string.Equals(selectedLanguage.Script, "Latn", StringComparison.OrdinalIgnoreCase);
     }
 
     public static Language? AsLanguage(this ILanguage iLanguage)

--- a/Text-Grab/Models/OcrOutput.cs
+++ b/Text-Grab/Models/OcrOutput.cs
@@ -1,4 +1,5 @@
 ﻿using System.Drawing;
+using Text_Grab.Interfaces;
 using Text_Grab.Properties;
 using Text_Grab.Utilities;
 using Windows.Graphics.Imaging;
@@ -13,7 +14,7 @@ public record OcrOutput
     public string CleanedOutput { get; set; } = string.Empty;
     public Bitmap? SourceBitmap { get; set; }
     public SoftwareBitmap? SourceSoftwareBitmap { get; set; }
-    public object? Language { get; set; }
+    public ILanguage? Language { get; set; }
 
     public void CleanOutput()
     {
@@ -23,7 +24,7 @@ public record OcrOutput
 
         string correctingString = RawOutput;
 
-        if (userSettings.CorrectToLatin)
+        if (userSettings.CorrectToLatin && Language?.IsLatinBased() == true)
             correctingString = correctingString.ReplaceGreekOrCyrillicWithLatin();
 
         if (userSettings.CorrectErrors)

--- a/Text-Grab/Models/ResultTable.cs
+++ b/Text-Grab/Models/ResultTable.cs
@@ -137,7 +137,10 @@ public class ResultTable
         return allBoundingRects;
     }
 
-    public static List<WordBorderInfo> ParseOcrResultIntoWordBorderInfos(IOcrLinesWords ocrResult, DpiScale dpi)
+    public static List<WordBorderInfo> ParseOcrResultIntoWordBorderInfos(
+        IOcrLinesWords ocrResult,
+        DpiScale dpi,
+        bool shouldCorrectToLatin = true)
     {
         List<WordBorderInfo> infos = [];
 
@@ -157,7 +160,7 @@ public class ResultTable
             };
 
             StringBuilder lineText = new();
-            ocrLine.GetTextFromOcrLine(true, lineText);
+            ocrLine.GetTextFromOcrLine(true, lineText, shouldCorrectToLatin);
 
             WordBorderInfo info = new()
             {

--- a/Text-Grab/Models/TessLang.cs
+++ b/Text-Grab/Models/TessLang.cs
@@ -128,7 +128,7 @@ public class TessLang : ILanguage
 
     public string NativeName => cultureInfo.NativeName;
 
-    public string Script => string.Empty;
+    public string Script => new Windows.Globalization.Language(cultureInfo.IetfLanguageTag).Script;
 
     public string LanguageTag => RawTag;
 

--- a/Text-Grab/Utilities/OcrUtilities.cs
+++ b/Text-Grab/Utilities/OcrUtilities.cs
@@ -50,7 +50,11 @@ public static partial class OcrUtilities
         return handle == IntPtr.Zero ? null : [handle];
     }
 
-    public static void GetTextFromOcrLine(this IOcrLine ocrLine, bool isSpaceJoiningOCRLang, StringBuilder text)
+    public static void GetTextFromOcrLine(
+        this IOcrLine ocrLine,
+        bool isSpaceJoiningOCRLang,
+        StringBuilder text,
+        bool shouldCorrectToLatin = true)
     {
         // (when OCR language is zh or ja)
         // matches words in a space-joining language, which contains:
@@ -98,7 +102,7 @@ public static partial class OcrUtilities
             }
         }
 
-        if (DefaultSettings.CorrectToLatin)
+        if (DefaultSettings.CorrectToLatin && shouldCorrectToLatin)
             text.ReplaceGreekOrCyrillicWithLatin();
     }
 
@@ -205,7 +209,10 @@ public static partial class OcrUtilities
         IOcrLinesWords ocrResult = await GetOcrResultFromImageAsync(scaledBitmap, compatibleLanguage);
 
         // New model-only flow
-        List<WordBorderInfo> wordBorderInfos = ResultTable.ParseOcrResultIntoWordBorderInfos(ocrResult, dpiScale);
+        List<WordBorderInfo> wordBorderInfos = ResultTable.ParseOcrResultIntoWordBorderInfos(
+            ocrResult,
+            dpiScale,
+            compatibleLanguage.IsLatinBased());
 
         Rectangle rectCanvasSize = new()
         {
@@ -250,7 +257,10 @@ public static partial class OcrUtilities
         IOcrLinesWords ocrResult = await GetOcrResultFromImageAsync(scaledBitmap, compatibleLanguage);
         DpiScale bitmapDpiScale = new(1.0, 1.0);
 
-        List<WordBorderInfo> wordBorderInfos = ResultTable.ParseOcrResultIntoWordBorderInfos(ocrResult, bitmapDpiScale);
+        List<WordBorderInfo> wordBorderInfos = ResultTable.ParseOcrResultIntoWordBorderInfos(
+            ocrResult,
+            bitmapDpiScale,
+            compatibleLanguage.IsLatinBased());
 
         Rectangle rectCanvasSize = new()
         {
@@ -626,7 +636,7 @@ public static partial class OcrUtilities
                 orderedLines = FilterFuriganaLines(orderedLines);
 
             foreach (IOcrLine ocrLine in orderedLines)
-                ocrLine.GetTextFromOcrLine(isSpaceJoiningOCRLang, text);
+                ocrLine.GetTextFromOcrLine(isSpaceJoiningOCRLang, text, language.IsLatinBased());
         }
 
         if (language.IsRightToLeft())

--- a/Text-Grab/Utilities/PdfDocumentRenderer.cs
+++ b/Text-Grab/Utilities/PdfDocumentRenderer.cs
@@ -436,7 +436,7 @@ internal sealed class PdfDocumentRenderer : IDisposable
         foreach (IOcrLine ocrLine in ocrResult.Lines)
         {
             StringBuilder textBuilder = new();
-            ocrLine.GetTextFromOcrLine(isSpaceJoiningLanguage, textBuilder);
+            ocrLine.GetTextFromOcrLine(isSpaceJoiningLanguage, textBuilder, language.IsLatinBased());
             textBuilder.RemoveTrailingNewlines();
 
             string lineText = textBuilder.ToString();

--- a/Text-Grab/Utilities/TesseractHelper.cs
+++ b/Text-Grab/Utilities/TesseractHelper.cs
@@ -114,6 +114,7 @@ public static class TesseractHelper
         {
             Engine = OcrEngineKind.Tesseract,
             Kind = OcrOutputKind.Paragraph,
+            Language = language,
             SourceBitmap = bmp,
             RawOutput = await TesseractHelper.GetTextFromImagePathAsync(TempImagePath(), language.RawTag)
         };

--- a/Text-Grab/Views/GrabFrame.xaml.cs
+++ b/Text-Grab/Views/GrabFrame.xaml.cs
@@ -1723,7 +1723,7 @@ public partial class GrabFrame : Window
         if (language is not UiAutomationLang && DefaultSettings.CorrectErrors)
             ocrText = ocrText.TryFixEveryWordLetterNumberErrors();
 
-        if (language is not UiAutomationLang && DefaultSettings.CorrectToLatin)
+        if (language is not UiAutomationLang && DefaultSettings.CorrectToLatin && language.IsLatinBased())
             ocrText = ocrText.ReplaceGreekOrCyrillicWithLatin();
 
         if (frameContentImageSource is BitmapImage bmpImg)
@@ -2177,7 +2177,7 @@ public partial class GrabFrame : Window
         if (DefaultSettings.CorrectErrors)
             wordText = wordText.TryFixNumberLetterErrors();
 
-        if (DefaultSettings.CorrectToLatin)
+        if (DefaultSettings.CorrectToLatin && CurrentLanguage?.IsLatinBased() == true)
             wordText = wordText.ReplaceGreekOrCyrillicWithLatin();
 
         return wordText;
@@ -2191,7 +2191,7 @@ public partial class GrabFrame : Window
     private string GetNormalizedOcrLineText(IOcrLine ocrLine)
     {
         StringBuilder lineText = new();
-        ocrLine.GetTextFromOcrLine(isSpaceJoining, lineText);
+        ocrLine.GetTextFromOcrLine(isSpaceJoining, lineText, CurrentLanguage?.IsLatinBased() == true);
         lineText.RemoveTrailingNewlines();
 
         string ocrText = lineText.ToString();
@@ -2199,7 +2199,7 @@ public partial class GrabFrame : Window
         if (DefaultSettings.CorrectErrors)
             ocrText = ocrText.TryFixEveryWordLetterNumberErrors();
 
-        if (DefaultSettings.CorrectToLatin)
+        if (DefaultSettings.CorrectToLatin && CurrentLanguage?.IsLatinBased() == true)
             ocrText = ocrText.ReplaceGreekOrCyrillicWithLatin();
 
         if (CurrentLanguage!.IsRightToLeft())
@@ -2470,7 +2470,7 @@ public partial class GrabFrame : Window
                 if (DefaultSettings.CorrectErrors)
                     lineText = lineText.TryFixEveryWordLetterNumberErrors();
 
-                if (DefaultSettings.CorrectToLatin)
+                if (DefaultSettings.CorrectToLatin && CurrentLanguage!.IsLatinBased())
                     lineText = lineText.ReplaceGreekOrCyrillicWithLatin();
             }
 


### PR DESCRIPTION
Fixes #669

## Summary
- Apply `CorrectToLatin` only when the selected capture language is Latin-based.
- Carry the capture language through paragraph, line/table, PDF, Tesseract, and Grab Frame OCR paths.
- Add regression coverage for Latin and Cyrillic capture languages.

## Testing
- `dotnet test Tests\Tests.csproj --no-restore --verbosity minimal` (1446 passed, 7 skipped)
- `dotnet test Tests\Tests.csproj --no-restore --filter 'FullyQualifiedName~CleanOutput_CorrectsOnlyLatinCaptureLanguages' --verbosity minimal` (2 passed)